### PR TITLE
Fix Broken Double Hyphen Case

### DIFF
--- a/unicode_hostname.go
+++ b/unicode_hostname.go
@@ -589,6 +589,7 @@ func ZeroWidthNonJoiner(val []rune, idx int) (ok bool) {
 // verifyRFC5891_4_2_3_1 ensures there are no leading, terminating, or double-hypens in the label
 func verifyRFC5891_4_2_3_1(label string) error {
 	var p, q rune
+	var i int
 	runeslice := []rune(label)
 	llen := len(runeslice) - 1
 
@@ -597,9 +598,9 @@ func verifyRFC5891_4_2_3_1(label string) error {
 		return errors.New("leading or trailing hyphen")
 	}
 
-	for _, p = range runeslice {
+	for i, p = range runeslice {
 		if unicode.Is(unicode.Properties["Hyphen"], p) &&
-			unicode.Is(unicode.Properties["Hyphen"], q) {
+			unicode.Is(unicode.Properties["Hyphen"], q) && i==3 {
 			return errors.New("Consecutive hyphens")
 		}
 		q = p

--- a/unicode_hostname_test.go
+++ b/unicode_hostname_test.go
@@ -87,9 +87,13 @@ func TestRFC5891DNSNegative(t *testing.T) {
 	err = RFC5891DNS(v)
 	require.Error(t, err)
 
-	v = "double--hyphen.com"
+	v = "no--hyphens.com"
 	err = RFC5891DNS(v)
 	require.Error(t, err)
+
+	v = "allowed--hyphens.com"
+	err = RFC5891DNS(v)
+	require.NoError(t, err)
 
 	v = "contains..nested.null.doma.in"
 	err = RFC5891DNS(v)

--- a/unicode_hostname_test.go
+++ b/unicode_hostname_test.go
@@ -87,7 +87,16 @@ func TestRFC5891DNSNegative(t *testing.T) {
 	err = RFC5891DNS(v)
 	require.Error(t, err)
 
+	// https://tools.ietf.org/html/rfc5891#section-4.2.3
 	v = "no--hyphens.com"
+	err = RFC5891DNS(v)
+	require.Error(t, err)
+
+	v = "v--alidhyphens.com"
+	err = RFC5891DNS(v)
+	require.NoError(t, err)
+
+	v = "val--idhyphens.com"
 	err = RFC5891DNS(v)
 	require.Error(t, err)
 

--- a/unicode_hostname_test.go
+++ b/unicode_hostname_test.go
@@ -98,7 +98,7 @@ func TestRFC5891DNSNegative(t *testing.T) {
 
 	v = "val--idhyphens.com"
 	err = RFC5891DNS(v)
-	require.Error(t, err)
+	require.NoError(t, err)
 
 	v = "allowed--hyphens.com"
 	err = RFC5891DNS(v)


### PR DESCRIPTION
It is explicitly stated in RFC 5891 (https://tools.ietf.org/html/rfc5891#section-4.2.3) that "The Unicode string MUST NOT contain "--" (two consecutive hyphens) in the third and fourth character positions and MUST NOT start or end with a "-" (hyphen)."  While the validator checks starting and ending hyphens it restricts all double hyphens, rather than only double hyphens in the third and fourth position. This PR adds an index check for double hyphens. 