### PR TITLE
Fix verifyRFC5891_4_2_3_1

### DIFF
--- a/unicode_hostname.go
+++ b/unicode_hostname.go
@@ -586,9 +586,8 @@ func ZeroWidthNonJoiner(val []rune, idx int) (ok bool) {
 	return ok
 }
 
-// verifyRFC5891_4_2_3_1 ensures there are no leading, terminating, or double-hypens in the label
+// verifyRFC5891_4_2_3_1 ensures there are no leading, terminating, or double-hypens @ pos 3 and 4 in the label
 func verifyRFC5891_4_2_3_1(label string) error {
-	var p, q rune
 	runeslice := []rune(label)
 	llen := len(runeslice) - 1
 
@@ -597,12 +596,12 @@ func verifyRFC5891_4_2_3_1(label string) error {
 		return errors.New("leading or trailing hyphen")
 	}
 
-	for _, p = range runeslice {
-		if unicode.Is(unicode.Properties["Hyphen"], p) &&
-			unicode.Is(unicode.Properties["Hyphen"], q) {
+	// A-labels (ASCII-compatible encoded (ACE) idns) are prefixed with `xn--`, hence this restriction
+	if len(runeslice) >= 4 {
+		if unicode.Is(unicode.Properties["Hyphen"], runeslice[2]) &&
+			unicode.Is(unicode.Properties["Hyphen"], runeslice[3]) {
 			return errors.New("Consecutive hyphens")
 		}
-		q = p
 	}
 	return nil
 }

--- a/unicode_hostname.go
+++ b/unicode_hostname.go
@@ -597,6 +597,7 @@ func verifyRFC5891_4_2_3_1(label string) error {
 	}
 
 	// A-labels (ASCII-compatible encoded (ACE) idns) are prefixed with `xn--`, hence this restriction
+	// TODO: This means A-labels will fail validation here.
 	if len(runeslice) >= 4 {
 		if unicode.Is(unicode.Properties["Hyphen"], runeslice[2]) &&
 			unicode.Is(unicode.Properties["Hyphen"], runeslice[3]) {

--- a/unicode_hostname_test.go
+++ b/unicode_hostname_test.go
@@ -100,6 +100,10 @@ func TestRFC5891DNSNegative(t *testing.T) {
 	err = RFC5891DNS(v)
 	require.Error(t, err)
 
+	v = "xn--28j2a3ar1pp75ovm7c.xn--28j2a3ar1pp75ovm7c.jp"
+	err = RFC5891DNS(v)
+	require.Error(t, err)
+
 	v = "contains..nested.null.doma.in"
 	err = RFC5891DNS(v)
 	require.Error(t, err)

--- a/unicode_hostname_test.go
+++ b/unicode_hostname_test.go
@@ -64,6 +64,15 @@ func TestRFC5891DNS(t *testing.T) {
 
 	err = RFC5891DNS("ԛәлп.com")
 	require.NoError(t, err)
+
+	err = RFC5891DNS("double--hyphen.com")
+	require.NoError(t, err)
+
+	err = RFC5891DNS("d--blehyphen.com")
+	require.NoError(t, err)
+
+	err = RFC5891DNS("dou--ehyphen.com")
+	require.NoError(t, err)
 }
 
 func TestRFC5891DNSNegative(t *testing.T) {
@@ -87,7 +96,7 @@ func TestRFC5891DNSNegative(t *testing.T) {
 	err = RFC5891DNS(v)
 	require.Error(t, err)
 
-	v = "double--hyphen.com"
+	v = "do--lehyphen.com"
 	err = RFC5891DNS(v)
 	require.Error(t, err)
 


### PR DESCRIPTION
The restriction is no double hyphen only in position 3 and 4 - we were checking the whole label incorrectly.